### PR TITLE
fixing MemoryManager and CallbackTask

### DIFF
--- a/src/pocketmine/MemoryManager.php
+++ b/src/pocketmine/MemoryManager.php
@@ -19,8 +19,6 @@
  *
 */
 
-declare(strict_types=1);
-
 namespace pocketmine;
 
 use pocketmine\event\server\LowMemoryEvent;
@@ -90,6 +88,11 @@ class MemoryManager{
 		}
 
 		$hardLimit = ((int) $this->server->getProperty("memory.main-hard-limit", $defaultMemory));
+
+		if(PHP_INT_SIZE === 4 and $hardLimit >= 4096){
+			$this->server->getLogger()->warning("Cannot set memory limit higher than 4GB on 32-bit, defaulting to max 4095MB");
+			$hardLimit = 4095;
+		}
 
 		if($hardLimit <= 0){
 			ini_set("memory_limit", -1);

--- a/src/pocketmine/scheduler/CallbackTask.php
+++ b/src/pocketmine/scheduler/CallbackTask.php
@@ -1,0 +1,64 @@
+<?php
+ 
+ /*
+  *
+  *  ____            _        _   __  __ _                  __  __ ____
+  * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+  * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+  * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+  * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+  *
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU Lesser General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * @author PocketMine Team
+  * @link http://www.pocketmine.net/
+  *
+  *
+ */
+ 
+ namespace pocketmine\scheduler;
+ 
+ /**
+  * Allows the creation of simple callbacks with extra data
+  * The last parameter in the callback will be this object
+  *
+  * If you want to do a task in a Plugin, consider extending PluginTask to your needs
+  *
+  * @deprecated 
+  * Do NOT use this anymore, it was deprecated a long time ago at PocketMine
+  * and will be removed at some stage in the future.
+  */
+ 
+ class CallbackTask extends Task{
+ 
+ 	/** @var callable */
+ 	protected $callable;
+ 
+ 	/** @var array */
+ 	protected $args;
+ 
+ 	/**
+ 	 * @param callable $callable
+ 	 * @param array    $args
+ 	 */
+ 	public function __construct(callable $callable, array $args = []){
+ 		$this->callable = $callable;
+ 		$this->args = $args;
+ 		$this->args[] = $this;
+ 	}
+ 
+ 	/**
+ 	 * @return callable
+ 	 */
+ 	public function getCallable(){
+ 		return $this->callable;
+ 	}
+ 
+ 	public function onRun($currentTicks){
+ 		call_user_func_array($this->callable, $this->args);
+ 	}
+ 
+ }


### PR DESCRIPTION
MemoryManager:
```
09:25:19 [CRITICAL] TypeError: "ini_set() expects parameter 2 to be string, integer given" (EXCEPTION) in "/src/pocketmine/MemoryManager" at line 95
09:25:19 [DEBUG] #0 /src/pocketmine/MemoryManager(62): pocketmine\MemoryManager->init(boolean)
09:25:19 [DEBUG] #1 /src/pocketmine/Server(1456): pocketmine\MemoryManager->__construct(pocketmine\Server object)
09:25:19 [DEBUG] #2 /src/pocketmine/PocketMine(499): pocketmine\Server->__construct(BaseClassLoader object, pocketmine\utils\MainLogger object, string /root/aquaWorld/, string /root/aquaWorld/, string /root/aquaWorld/plugins/)
```

CallbackTask:` ClassNotFoundException: "Class pocketmine\scheduler\CallbackTask not found"`
